### PR TITLE
add visitor pattern + pass alive logic

### DIFF
--- a/cc/mcts/gumbel.cc
+++ b/cc/mcts/gumbel.cc
@@ -267,8 +267,11 @@ std::vector<TreeNode*> GumbelEvaluator::SearchNonRoot(
 
   if (board.IsGameOver() && !leaf_node->is_terminal) {
     // evaluate score
-    float player_score = board.Score(color_to_move);
-    float opp_score = board.Score(game::OppositeColor(color_to_move));
+    game::Scores scores = board.GetScores();
+    float player_score =
+        color_to_move == BLACK ? scores.black_score : scores.white_score;
+    float opp_score =
+        color_to_move == BLACK ? scores.white_score : scores.black_score;
     float final_score =
         player_score - opp_score + constants::kScoreInflectionPoint;
     float empirical_q =

--- a/cc/scripts/play_model.cc
+++ b/cc/scripts/play_model.cc
@@ -102,9 +102,11 @@ int main(int argc, char** argv) {
     sleep(1);
   }
 
+  game::Scores scores = board.GetScores();
+
   LOG(INFO) << "Game Over: ";
-  LOG(INFO) << "  Black Score: " << board.Score(BLACK);
-  LOG(INFO) << "  White Score: " << board.Score(WHITE);
+  LOG(INFO) << "  Black Score: " << scores.black_score;
+  LOG(INFO) << "  White Score: " << scores.white_score;
 
   return 0;
 }

--- a/cc/scripts/ucb_scratch.cc
+++ b/cc/scripts/ucb_scratch.cc
@@ -216,8 +216,9 @@ int UcbRandomPlayout(game::Board& board, Tree& tree, int color_to_move,
     }
   }
 
-  int b_score = board.BlackScore();
-  int w_score = board.WhiteScore();
+  game::Scores scores = board.GetScores();
+  int b_score = scores.black_score;
+  int w_score = scores.white_score;
 
   return b_score > w_score ? BLACK : WHITE;
 }
@@ -225,8 +226,9 @@ int UcbRandomPlayout(game::Board& board, Tree& tree, int color_to_move,
 int UcbSearch(game::Board& board, Tree& tree, int color_to_move) {
   GameState game_state = GameState{board.hash(), color_to_move};
   if (board.IsGameOver()) {
-    int b_score = board.BlackScore();
-    int w_score = board.WhiteScore();
+    game::Scores scores = board.GetScores();
+    int b_score = scores.black_score;
+    int w_score = scores.white_score;
     int winner = b_score > w_score ? BLACK : WHITE;
 
     if (!tree.contains(game_state)) {

--- a/cc/self_play_thread.cc
+++ b/cc/self_play_thread.cc
@@ -86,7 +86,8 @@ void ExecuteSelfPlay(int thread_id, nn::NNInterface* nn_interface,
   }
 
   nn_interface->UnregisterThread(thread_id);
+  game::Scores scores = board.GetScores();
 
-  LOG(INFO).ToSinkOnly(&sink) << "Black Score: " << board.BlackScore();
-  LOG(INFO).ToSinkOnly(&sink) << "White Score: " << board.WhiteScore();
+  LOG(INFO).ToSinkOnly(&sink) << "Black Score: " << scores.black_score;
+  LOG(INFO).ToSinkOnly(&sink) << "White Score: " << scores.white_score;
 }


### PR DESCRIPTION
1. refactor board code to use visitor pattern.
2. prohibit moving in pass-alive regions after (2) passes.
3. count unconditionally dead stones in final score (i.e. stones in pass-alive regions of the opposite color).